### PR TITLE
Update layout asset load order

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -9,11 +9,18 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= current_page.data.title || "Rails Camp Adelaide" %></title>
 
-    <%= stylesheet_link_tag :site %>
+    <!-- Javascript -->
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?callback=initMap" async defer></script>
     <%= javascript_include_tag :all %>
 
+    <!-- Fonts -->
     <link href='//fonts.googleapis.com/css?family=Lato:300,400' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+
+    <!-- Styles -->
+    <%= stylesheet_link_tag :site %>
   </head>
 
   <body class="<%= page_classes %>">
@@ -64,15 +71,5 @@
       // Design inspiration from Rob McFadzean
     </p>
   </footer>
-  <!-- Bootstrap core JavaScript
-  ================================================== -->
-  <!-- Placed at the end of the document so the pages load faster -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
-  <script src="../../dist/js/bootstrap.min.js"></script>
-  <script src="../../assets/js/docs.min.js"></script>
-  <script src="https://maps.googleapis.com/maps/api/js?callback=initMap" async defer></script>
-  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-  <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I've rearranged the load order of the assets, not sure exactly what issue you were having but I'm guessing it was a load order issue. Being that jQuery was outside of the `<head></head>` it would not have been loaded in time for any project scripts that depended on it.

Have a look, feel free to just test off my branch instead of merging into your own.
